### PR TITLE
Implement independent Sprints

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages;
 
+use App\Filament\Widgets\ActiveSprints;
 use App\Filament\Widgets\FavoriteProjects;
 use App\Filament\Widgets\LatestActivities;
 use App\Filament\Widgets\LatestComments;
@@ -26,6 +27,7 @@ class Dashboard extends BasePage
     protected function getWidgets(): array
     {
         return [
+            ActiveSprints::class,
             FavoriteProjects::class,
             LatestActivities::class,
             LatestComments::class,

--- a/app/Filament/Resources/ProjectResource.php
+++ b/app/Filament/Resources/ProjectResource.php
@@ -27,7 +27,7 @@ class ProjectResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-archive';
 
-    protected static ?int $navigationSort = 1;
+    protected static ?int $navigationSort = 3;
 
     protected static function getNavigationLabel(): string
     {

--- a/app/Filament/Resources/SprintResource.php
+++ b/app/Filament/Resources/SprintResource.php
@@ -70,7 +70,7 @@ class SprintResource extends Resource
                                     ->label(__('Tickets Credits'))
                                     ->numeric()
                                     ->disabled()
-                                    ->dehydrate(false),
+                                    ->dehydrated(false),
                                 Forms\Components\TextInput::make('extra_credits')
                                     ->label(__('Extra Credits'))
                                     ->numeric()
@@ -79,7 +79,7 @@ class SprintResource extends Resource
                                     ->label(__('Total Credits'))
                                     ->numeric()
                                     ->disabled()
-                                    ->dehydrate(false),
+                                    ->dehydrated(false),
                                 Forms\Components\Toggle::make('billed')
                                     ->label(__('Billed')),
                             ])->columns(2)

--- a/app/Filament/Resources/SprintResource.php
+++ b/app/Filament/Resources/SprintResource.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\SprintResource\Pages;
+use App\Models\Client;
+use App\Models\Sprint;
+use App\Models\Ticket;
+use App\Models\TicketStatus;
+use Filament\Facades\Filament;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables;
+use Illuminate\Support\HtmlString;
+
+class SprintResource extends Resource
+{
+    protected static ?string $model = Sprint::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-fast-forward';
+
+    protected static ?int $navigationSort = 2;
+
+    protected static function getNavigationLabel(): string
+    {
+        return __('Sprints');
+    }
+
+    public static function getPluralLabel(): ?string
+    {
+        return static::getNavigationLabel();
+    }
+
+    protected static function getNavigationGroup(): ?string
+    {
+        return __('Management');
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Card::make()
+                    ->schema([
+                        Forms\Components\Grid::make()
+                            ->schema([
+                                Forms\Components\TextInput::make('name')
+                                    ->label(__('Sprint name'))
+                                    ->required()
+                                    ->maxLength(255),
+                                Forms\Components\Select::make('client_id')
+                                    ->label(__('Client'))
+                                    ->searchable()
+                                    ->options(fn() => Client::all()->pluck('name','id')->toArray())
+                                    ->required(),
+                                Forms\Components\DatePicker::make('starts_at')
+                                    ->label(__('Sprint start date'))
+                                    ->reactive()
+                                    ->afterStateUpdated(fn($state, $set) => $set('ends_at', \Carbon\Carbon::parse($state)->addWeek()->subDay()))
+                                    ->required(),
+                                Forms\Components\DatePicker::make('ends_at')
+                                    ->label(__('Sprint end date'))
+                                    ->required(),
+                                Forms\Components\RichEditor::make('description')
+                                    ->label(__('Sprint description'))
+                                    ->columnSpanFull(),
+                                Forms\Components\TextInput::make('tickets_credits')
+                                    ->label(__('Tickets Credits'))
+                                    ->numeric()
+                                    ->disabled()
+                                    ->dehydrate(false),
+                                Forms\Components\TextInput::make('extra_credits')
+                                    ->label(__('Extra Credits'))
+                                    ->numeric()
+                                    ->default(0),
+                                Forms\Components\TextInput::make('total_credits')
+                                    ->label(__('Total Credits'))
+                                    ->numeric()
+                                    ->disabled()
+                                    ->dehydrate(false),
+                                Forms\Components\Toggle::make('billed')
+                                    ->label(__('Billed')),
+                            ])->columns(2)
+                    ])
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('Sprint name'))
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('client.name')
+                    ->label(__('Client')),
+                Tables\Columns\TextColumn::make('starts_at')
+                    ->label(__('Sprint start date'))
+                    ->date()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('ends_at')
+                    ->label(__('Sprint end date'))
+                    ->date()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('tickets_credits')
+                    ->label(__('Tickets Credits')),
+                Tables\Columns\TextColumn::make('extra_credits')
+                    ->label(__('Extra Credits')),
+                Tables\Columns\TextColumn::make('total_credits')
+                    ->label(__('Total Credits')),
+                Tables\Columns\IconColumn::make('billed')
+                    ->label(__('Billed'))
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('started_at')
+                    ->label(__('Sprint started at'))
+                    ->dateTime(),
+                Tables\Columns\TextColumn::make('ended_at')
+                    ->label(__('Sprint ended at'))
+                    ->dateTime(),
+                Tables\Columns\TextColumn::make('remaining')
+                    ->label(__('Remaining'))
+                    ->suffix(fn($record) => $record->remaining ? ' '. __('days') : ''),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('start')
+                    ->label(__('Start sprint'))
+                    ->visible(fn($record) => !$record->started_at && !$record->ended_at)
+                    ->requiresConfirmation()
+                    ->color('success')
+                    ->button()
+                    ->icon('heroicon-o-play')
+                    ->action(function (Sprint $record) {
+                        $now = now();
+                        Sprint::whereNotNull('started_at')
+                            ->whereNull('ended_at')
+                            ->update(['ended_at' => $now]);
+                        $record->started_at = $now;
+                        $record->save();
+                        Filament::notify('success', __('Sprint started at').' '.$now);
+                    }),
+                Tables\Actions\Action::make('stop')
+                    ->label(__('Stop sprint'))
+                    ->visible(fn($record) => $record->started_at && !$record->ended_at)
+                    ->requiresConfirmation()
+                    ->color('danger')
+                    ->button()
+                    ->icon('heroicon-o-pause')
+                    ->action(function (Sprint $record) {
+                        $now = now();
+                        $record->ended_at = $now;
+                        $record->save();
+                        Filament::notify('success', __('Sprint ended at').' '.$now);
+                    }),
+                Tables\Actions\Action::make('tickets')
+                    ->label(__('Tickets'))
+                    ->color('secondary')
+                    ->icon('heroicon-o-ticket')
+                    ->mountUsing(fn(Forms\ComponentContainer $form, Sprint $record) => $form->fill([
+                        'tickets' => $record->tickets->pluck('id')->toArray()
+                    ]))
+                    ->modalHeading(fn($record) => $record->name.' - '.__('Associated tickets'))
+                    ->form([
+                        Forms\Components\CheckboxList::make('tickets')
+                            ->label(__('Choose tickets to associate to this sprint'))
+                            ->required()
+                            ->options(function (Sprint $record) {
+                                $backlog = TicketStatus::where('name', 'Backlog')->first();
+                                $results = [];
+                                $tickets = Ticket::where('client_id', $record->client_id)
+                                    ->where(function ($query) use ($record, $backlog) {
+                                        $query->where('status_id', $backlog->id)
+                                            ->orWhere('sprint_id', $record->id);
+                                    })->get();
+                                foreach ($tickets as $ticket) {
+                                    $results[$ticket->id] = new HtmlString('<div class="w-full flex justify-between items-center">'
+                                        .'<span>'.$ticket->name.'</span>'
+                                        .($ticket->sprint ? '<span class="text-xs font-medium '.($ticket->sprint_id == $record->id ? 'bg-gray-100 text-gray-600' : 'bg-danger-500 text-white').' px-2 py-1 rounded">'.$ticket->sprint->name.'</span>' : '')
+                                        .'</div>');
+                                }
+                                return $results;
+                            })
+                    ])
+                    ->action(function (Sprint $record, array $data) {
+                        $tickets = $data['tickets'];
+                        Ticket::where('sprint_id', $record->id)->update(['sprint_id' => null]);
+                        $statusSprint = TicketStatus::where('name', 'Sprint')->first();
+                        Ticket::whereIn('id', $tickets)->update(['sprint_id' => $record->id, 'status_id' => $statusSprint->id]);
+                        $record->save();
+                        Filament::notify('success', __('Tickets associated with sprint'));
+                    }),
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\DeleteBulkAction::make(),
+            ])
+            ->defaultSort('id');
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSprints::route('/'),
+            'create' => Pages\CreateSprint::route('/create'),
+            'view' => Pages\ViewSprint::route('/{record}'),
+            'edit' => Pages\EditSprint::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SprintResource/Pages/CreateSprint.php
+++ b/app/Filament/Resources/SprintResource/Pages/CreateSprint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SprintResource\Pages;
+
+use App\Filament\Resources\SprintResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSprint extends CreateRecord
+{
+    protected static string $resource = SprintResource::class;
+}

--- a/app/Filament/Resources/SprintResource/Pages/EditSprint.php
+++ b/app/Filament/Resources/SprintResource/Pages/EditSprint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SprintResource\Pages;
+
+use App\Filament\Resources\SprintResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSprint extends EditRecord
+{
+    protected static string $resource = SprintResource::class;
+}

--- a/app/Filament/Resources/SprintResource/Pages/ListSprints.php
+++ b/app/Filament/Resources/SprintResource/Pages/ListSprints.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\SprintResource\Pages;
+
+use App\Filament\Resources\SprintResource;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSprints extends ListRecords
+{
+    protected static string $resource = SprintResource::class;
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/SprintResource/Pages/ViewSprint.php
+++ b/app/Filament/Resources/SprintResource/Pages/ViewSprint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SprintResource\Pages;
+
+use App\Filament\Resources\SprintResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewSprint extends ViewRecord
+{
+    protected static string $resource = SprintResource::class;
+}

--- a/app/Filament/Widgets/ActiveSprints.php
+++ b/app/Filament/Widgets/ActiveSprints.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Sprint;
+use Filament\Tables;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+
+class ActiveSprints extends BaseWidget
+{
+    protected static ?int $sort = 1;
+    protected int|string|array $columnSpan = [
+        'sm' => 1,
+        'md' => 6,
+        'lg' => 3,
+    ];
+
+    public function mount(): void
+    {
+        self::$heading = __('Active sprints');
+    }
+
+    public static function canView(): bool
+    {
+        return auth()->user()->can('List sprints');
+    }
+
+    protected function isTablePaginationEnabled(): bool
+    {
+        return false;
+    }
+
+    protected function getTableQuery(): Builder
+    {
+        return Sprint::query()
+            ->whereDate('starts_at', '<=', now())
+            ->whereDate('ends_at', '>=', now());
+    }
+
+    protected function getTableColumns(): array
+    {
+        return [
+            Tables\Columns\TextColumn::make('name')->label(__('Sprint name')),
+            Tables\Columns\TextColumn::make('client.name')->label(__('Client')),
+            Tables\Columns\TextColumn::make('ends_at')->label(__('Sprint end date'))->date(),
+        ];
+    }
+}

--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -15,8 +15,17 @@ class Sprint extends Model
     use HasFactory, SoftDeletes;
 
     protected $fillable = [
-        'name', 'starts_at', 'ends_at', 'description',
-        'project_id', 'started_at', 'ended_at'
+        'name',
+        'starts_at',
+        'ends_at',
+        'description',
+        'client_id',
+        'tickets_credits',
+        'extra_credits',
+        'total_credits',
+        'billed',
+        'started_at',
+        'ended_at',
     ];
 
     protected $casts = [
@@ -24,27 +33,20 @@ class Sprint extends Model
         'ends_at' => 'date',
         'started_at' => 'datetime',
         'ended_at' => 'datetime',
+        'billed' => 'boolean',
     ];
 
-    public static function boot()
+    protected static function booted()
     {
-        parent::boot();
-
-        static::created(function (Sprint $item) {
-            $epic = Epic::create([
-                'name' => $item->name,
-                'starts_at' => $item->starts_at,
-                'ends_at' => $item->ends_at,
-                'project_id' => $item->project_id
-            ]);
-            $item->epic_id = $epic->id;
-            $item->save();
+        static::saving(function (Sprint $item) {
+            $item->tickets_credits = $item->tickets()->sum('credits');
+            $item->total_credits = ($item->tickets_credits ?? 0) + ($item->extra_credits ?? 0);
         });
     }
 
-    public function project(): BelongsTo
+    public function client(): BelongsTo
     {
-        return $this->belongsTo(Project::class, 'project_id', 'id');
+        return $this->belongsTo(Client::class, 'client_id', 'id');
     }
 
     public function tickets(): HasMany

--- a/app/Policies/SprintPolicy.php
+++ b/app/Policies/SprintPolicy.php
@@ -30,12 +30,7 @@ class SprintPolicy
      */
     public function view(User $user, Sprint $sprint)
     {
-        return $user->can('View sprint')
-            && (
-                $sprint->project->owner_id === $user->id
-                ||
-                $sprint->project->users()->where('users.id', $user->id)->count()
-            );
+        return $user->can('View sprint');
     }
 
     /**
@@ -58,14 +53,7 @@ class SprintPolicy
      */
     public function update(User $user, Sprint $sprint)
     {
-        return $user->can('Update sprint')
-            && (
-                $sprint->project->owner_id === $user->id
-                ||
-                $sprint->project->users()->where('users.id', $user->id)
-                    ->where('role', config('system.projects.affectations.roles.can_manage'))
-                    ->count()
-            );
+        return $user->can('Update sprint');
     }
 
     /**

--- a/database/migrations/2025_06_16_100000_update_sprints_fields.php
+++ b/database/migrations/2025_06_16_100000_update_sprints_fields.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table('sprints', function (Blueprint $table) {
+            if (Schema::hasColumn('sprints', 'project_id')) {
+                $table->dropForeign(['project_id']);
+                $table->dropColumn('project_id');
+            }
+            $table->foreignId('client_id')->nullable()->constrained('clients');
+            $table->integer('tickets_credits')->nullable();
+            $table->integer('extra_credits')->default(0);
+            $table->integer('total_credits')->nullable();
+            $table->boolean('billed')->default(false);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('sprints', function (Blueprint $table) {
+            $table->dropColumn(['client_id','tickets_credits','extra_credits','total_credits','billed']);
+            $table->foreignId('project_id')->constrained('projects');
+        });
+    }
+};

--- a/database/seeders/SprintSeeder.php
+++ b/database/seeders/SprintSeeder.php
@@ -21,7 +21,7 @@ class SprintSeeder extends Seeder
             'starts_at' => '2025-06-01',
             'ends_at' => '2025-06-30',
             'description' => '<p>Test example #1</p>',
-            'project_id' => 1,
+            'client_id' => 2,
         ],
     ];
 

--- a/database/seeders/TicketSeeder.php
+++ b/database/seeders/TicketSeeder.php
@@ -29,6 +29,7 @@ class TicketSeeder extends Seeder
             'priority_id' => 2,
             'estimation' => '04:30:00',
             'credits' => 1,
+            'client_id' => 2,
         ],
         [
             'name' => 'Ticket Example #2',
@@ -41,9 +42,9 @@ class TicketSeeder extends Seeder
             'type_id' => 2,
             'order' => 1,
             'priority_id' => 2,
-            'estimation' => '04:30:00',
-            'credits' => 1,
-            'sprint_id' => 1,
+            'estimation' => '08:00:00',
+            'credits' => 2,
+            'client_id' => 2,
         ],
         [
             'name' => 'Ticket Example #3',
@@ -58,6 +59,7 @@ class TicketSeeder extends Seeder
             'priority_id' => 2,
             'estimation' => '04:30:00',
             'credits' => 1,
+            'client_id' => 1,
         ],
     ];
 


### PR DESCRIPTION
## Summary
- add migration to update sprints table
- compute sprint credits on save and relate sprints to clients
- create SprintResource with Filament pages
- show active sprints widget on dashboard
- adjust Project navigation order
- simplify SprintPolicy

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68505f3103ec83269ab6d5e5b6073f4b